### PR TITLE
Out(views|css) correctly created the parent diretory

### DIFF
--- a/cmd/webgen/webgen.go
+++ b/cmd/webgen/webgen.go
@@ -139,7 +139,7 @@ func main() {
 }
 
 func createFile(p string) *os.File {
-	err := os.MkdirAll(filepath.Base(p), permDir)
+	err := os.MkdirAll(filepath.Dir(p), permDir)
 	if err != nil {
 		stderr.Printf("%s", err)
 		os.Exit(1)


### PR DESCRIPTION
Without this fix `webgen --outviews=test.go` would create a folder named `test.go` and fail to open it as a file